### PR TITLE
Rollback loom and update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ public static final ComponentType<IntComponent> MAGIK =
         ComponentRegistry.INSTANCE.registerIfAbsent(new Identifier("mymod:magik"), IntComponent.class);
 
 public static void useMagik(ComponentProvider provider) {
+    // Retrieve a provided component
     int magik = MAGIK.get(provider).getValue();
+    // Or, if the provider is not guaranteed to provide that component:
+    int magik = MAGIK.maybeGet(provider).map(IntComponent::getValue).orElse(0);
     // ...
 }
 ```
@@ -93,8 +96,8 @@ If you have issues when attaching components to item stacks, it usually means yo
 
 **Example:**
 ```java
-// Add the component to every stack of diamond pick
-ItemComponentCallback.event(Items.DIAMOND_PICKAXE).register((stack, components) -> components.put(MAGIK, new RandomIntComponent()));
+// Add the component to every stack of wasted diamonds
+ItemComponentCallback.event(Items.DIAMOND_HOE).register((stack, components) -> components.put(MAGIK, new RandomIntComponent()));
 ```
 
 *module: cardinal-components-item*
@@ -137,6 +140,11 @@ Chunk components are saved automatically with the chunk. Synchronization must be
 help of the [`SyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/component/extension/SyncedComponent.java) 
 and [`ChunkSyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-chunk/src/main/java/nerdhub/cardinal/components/api/util/sync/ChunkSyncedComponent.java) interfaces.
 
+**Notes:**
+- `EmptyChunk`: empty chunks never expose any components, no matter what was originally attached to them.
+As such, when chunk components are queried on the client, one should make sure the chunk is loaded, or use
+`ComponentType#maybeGet` to retrieve a component.
+
 **Example:**
 ```java
 // Add the component to every chunk in every world
@@ -151,7 +159,7 @@ Blocks actually implement the `BlockComponentProvider` interface instead of the 
 Custom blocks may re-implement that interface themselves to provide components independently of the presence of
 a BlockEntity. Usually the block simply proxies its Block Entity, however the Block Entity does not need to 
 implement `BlockComponentProvider` if the block already has a custom implementation. Block components can be
-slightly less convenient to provide as they require their own implementations, but several utility classes
+slightly less convenient to provide as they require their own implementations, but [several utility classes](https://github.com/NerdHubMC/Cardinal-Components-API/tree/master/cardinal-components-block/src/main/java/nerdhub/cardinal/components/api/util/sided)
 are available to help.
 
 Components are entirely compatible with [LibBlockAttributes](https://github.com/AlexIIL/LibBlockAttributes)' attributes.

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings "net.fabricmc:yarn:${rootProject.minecraft_version}+build.${rootProject.yarn_mappings}"
-        modImplementation "net.fabricmc:fabric-loader:${rootProject.loader_version}"
+        modApi "net.fabricmc:fabric-loader:${rootProject.loader_version}"
         modApi("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
         modImplementation("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.0-M1"

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ allprojects {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings "net.fabricmc:yarn:${rootProject.minecraft_version}+build.${rootProject.yarn_mappings}"
         modImplementation "net.fabricmc:fabric-loader:${rootProject.loader_version}"
+        modApi("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
+        modImplementation("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.0-M1"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.0-M1"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
@@ -110,21 +112,24 @@ dependencies {
             include it
         }
     }
-    //loom.deobf testImplementation(sourceSets.main.output) //FIXME deobf + test doesn't work?
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifact(file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar"))
-            pom.withXml {
-                def depsNode = asNode().appendNode("dependencies")
-                subprojects.each {
-                    def depNode = depsNode.appendNode("dependency")
-                    depNode.appendNode("groupId", it.group)
-                    depNode.appendNode("artifactId", it.name)
-                    depNode.appendNode("version", it.version)
-                    depNode.appendNode("scope", "compile")
+afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                artifact(remapJar.output) {
+                    builtBy remapJar
+                }
+                pom.withXml {
+                    def depsNode = asNode().appendNode("dependencies")
+                    subprojects.each {
+                        def depNode = depsNode.appendNode("dependency")
+                        depNode.appendNode("groupId", it.group)
+                        depNode.appendNode("artifactId", it.name)
+                        depNode.appendNode("version", it.version)
+                        depNode.appendNode("scope", "compile")
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Year
 
 plugins {
-    id "moe.nikky.fabric-loom" version "0.2.6-SNAPSHOT"
+    id "fabric-loom" version "0.2.4-SNAPSHOT"
     id "net.minecrell.licenser" version "0.2.1"
     id "com.matthewprenger.cursegradle" version "1.2.0"
     id "maven-publish"
@@ -13,7 +13,7 @@ group = "com.github.NerdHubMC"
 archivesBaseName = "Cardinal-Components-API"
 
 subprojects {
-    apply plugin: 'moe.nikky.fabric-loom'
+    apply plugin: 'fabric-loom'
     apply plugin: 'net.minecrell.licenser'
     apply plugin: 'com.matthewprenger.cursegradle'
     apply plugin: 'maven-publish'
@@ -40,7 +40,7 @@ allprojects {
     dependencies {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         mappings "net.fabricmc:yarn:${rootProject.minecraft_version}+build.${rootProject.yarn_mappings}"
-        fabricInstall "net.fabricmc:fabric-loader:${rootProject.loader_version}"
+        modImplementation "net.fabricmc:fabric-loader:${rootProject.loader_version}"
         testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.0-M1"
         testImplementation "org.junit.jupiter:junit-jupiter-params:5.5.0-M1"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
@@ -96,12 +96,12 @@ subprojects.each { remapJar.dependsOn("${it.path}:remapJar") }
 
 dependencies {
     // used by the test mod
-    loom.deobf implementation("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
-    loom.deobf implementation("net.fabricmc.fabric-api:fabric-object-builders-v0:${fabric_object_builders_version}")
-    loom.deobf runtime("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
-    loom.deobf runtime("net.fabricmc.fabric-api:fabric-resource-loader-v0:${fabric_resource_loader_version}")
-    loom.deobf runtime("net.fabricmc.fabric-api:fabric-mining-levels-v0:${fabric_mining_levels_version}")
-    loom.deobf runtime("net.fabricmc.fabric-api:fabric-tag-extensions-v0:${fabric_tag_extensions_version}")
+    modImplementation("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
+    modImplementation("net.fabricmc.fabric-api:fabric-object-builders-v0:${fabric_object_builders_version}")
+    modRuntime("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
+    modRuntime("net.fabricmc.fabric-api:fabric-resource-loader-v0:${fabric_resource_loader_version}")
+    modRuntime("net.fabricmc.fabric-api:fabric-mining-levels-v0:${fabric_mining_levels_version}")
+    modRuntime("net.fabricmc.fabric-api:fabric-tag-extensions-v0:${fabric_tag_extensions_version}")
 
     include "net.fabricmc.fabric-api:fabric-api-base:${fabric_base_version}"
     afterEvaluate {

--- a/cardinal-components-base/build.gradle
+++ b/cardinal-components-base/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    loom.deobf api("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
-    loom.deobf api("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
+    modApi("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
+    modApi("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
     testCompileOnly "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/cardinal-components-base/build.gradle
+++ b/cardinal-components-base/build.gradle
@@ -1,5 +1,3 @@
 dependencies {
-    modApi("net.fabricmc.fabric-api:fabric-api-base:${rootProject.fabric_base_version}")
-    modApi("net.fabricmc.fabric-api:fabric-networking-v0:${rootProject.fabric_networking_version}")
     testCompileOnly "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/util/ObjectPath.java
+++ b/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/util/ObjectPath.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Represents a function that extracts a property from a given object.
@@ -148,6 +149,27 @@ public interface ObjectPath<T, R> extends Function<T, R> {
         return (s) -> {
             R r = this.apply(s);
             return r != null ? after.apply(r) : null;
+        };
+    }
+
+    /**
+     * Returns a composed function that first applies this function to
+     * its input, and then calls {@code other} if there is no result.
+     * If evaluation of either function throws an exception, it is relayed to
+     * the caller of the composed function.
+     *
+     * @param other a {@code Supplier} whose result is returned if no value
+     * is present
+     * @return a composed function that first applies this function and then
+     * returns the result or calls {@code other} if none is given
+     * @throws NullPointerException if other is null
+     * @see Optional#orElseGet(Supplier)
+     */
+    default ObjectPath<T, R> orElseGet(Supplier<R> other) {
+        Objects.requireNonNull(other);
+        return (s) -> {
+            R r = this.apply(s);
+            return r != null ? r : other.get();
         };
     }
 

--- a/cardinal-components-chunk/src/main/java/nerdhub/cardinal/components/api/util/sync/ChunkSyncedComponent.java
+++ b/cardinal-components-chunk/src/main/java/nerdhub/cardinal/components/api/util/sync/ChunkSyncedComponent.java
@@ -23,6 +23,7 @@
 package nerdhub.cardinal.components.api.util.sync;
 
 import io.netty.buffer.Unpooled;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
 import nerdhub.cardinal.components.api.util.ChunkComponent;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
@@ -35,6 +36,9 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.WorldChunk;
 
+/**
+ * Default implementations of {@link SyncedComponent} methods, specialized for chunk components
+ */
 public interface ChunkSyncedComponent extends ChunkComponent, BaseSyncedComponent {
     /**
      * {@link CustomPayloadS2CPacket} channel for default chunk component synchronization.

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/sync/EntitySyncedComponent.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/sync/EntitySyncedComponent.java
@@ -23,15 +23,26 @@
 package nerdhub.cardinal.components.api.util.sync;
 
 import io.netty.buffer.Unpooled;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 import net.fabricmc.fabric.api.server.PlayerStream;
+import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.entity.Entity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
+/**
+ * Default implementations of {@link SyncedComponent} methods, specialized for entity components
+ */
 public interface EntitySyncedComponent extends BaseSyncedComponent {
+    /**
+     * {@link CustomPayloadS2CPacket} channel for default entity component synchronization.
+     * Packets emitted on this channel must begin with, in order, the {@link Entity#getEntityId() entity id} (as an int),
+     * and the {@link ComponentType#getId() component's type} (as an Identifier).
+     */
     Identifier PACKET_ID = new Identifier("cardinal-components", "entity_sync");
 
     Entity getEntity();

--- a/cardinal-components-level/src/main/java/nerdhub/cardinal/components/api/util/sync/LevelSyncedComponent.java
+++ b/cardinal-components-level/src/main/java/nerdhub/cardinal/components/api/util/sync/LevelSyncedComponent.java
@@ -23,15 +23,26 @@
 package nerdhub.cardinal.components.api.util.sync;
 
 import io.netty.buffer.Unpooled;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 import net.fabricmc.fabric.api.server.PlayerStream;
+import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 
+/**
+ * Default implementations of {@link SyncedComponent} methods, specialized for level components
+ */
 public interface LevelSyncedComponent extends BaseSyncedComponent {
+    /**
+     * {@link CustomPayloadS2CPacket} channel for default level component
+     * synchronization. Packets emitted on this channel must begin with the
+     * {@link ComponentType#getId() component's type} (as an Identifier).
+     */
     Identifier PACKET_ID = new Identifier("cardinal-components", "level_sync");
 
     /**

--- a/cardinal-components-world/src/main/java/nerdhub/cardinal/components/api/util/sync/WorldSyncedComponent.java
+++ b/cardinal-components-world/src/main/java/nerdhub/cardinal/components/api/util/sync/WorldSyncedComponent.java
@@ -23,15 +23,26 @@
 package nerdhub.cardinal.components.api.util.sync;
 
 import io.netty.buffer.Unpooled;
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.extension.SyncedComponent;
 import net.fabricmc.fabric.api.network.PacketContext;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
 import net.fabricmc.fabric.api.server.PlayerStream;
+import net.minecraft.client.network.packet.CustomPayloadS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.PacketByteBuf;
 import net.minecraft.world.World;
 
+/**
+ * Default implementations of {@link SyncedComponent} methods, specialized for world components
+ */
 public interface WorldSyncedComponent extends BaseSyncedComponent {
+    /**
+     * {@link CustomPayloadS2CPacket} channel for default world component
+     * synchronization. Packets emitted on this channel must begin with the
+     * {@link ComponentType#getId() component's type} (as an Identifier).
+     */
     Identifier PACKET_ID = new Identifier("cardinal-components", "world_sync");
 
     World getWorld();


### PR DESCRIPTION
Since loom 0.2.6 is not working out too well, this PR rollbacks to 0.2.4. The readme got a few changes as well. I am also throwing in a slight ObjectPath upgrade that I figured was quite lacking.