### PR TITLE
Fix networking initialization causing server crashes

### DIFF
--- a/cardinal-components-chunk/src/main/resources/fabric.mod.json
+++ b/cardinal-components-chunk/src/main/resources/fabric.mod.json
@@ -9,6 +9,9 @@
     "entrypoints": {
         "main": [
             "nerdhub.cardinal.components.internal.ComponentsChunkNetworking::init"
+        ],
+        "client": [
+            "nerdhub.cardinal.components.internal.ComponentsChunkNetworking::initClient"
         ]
     },
     "custom": {

--- a/cardinal-components-entity/src/main/resources/fabric.mod.json
+++ b/cardinal-components-entity/src/main/resources/fabric.mod.json
@@ -8,7 +8,9 @@
     "side": "universal",
     "entrypoints": {
         "main": [
-            "nerdhub.cardinal.components.ComponentsEntityNetworking::init"
+        ],
+        "client": [
+            "nerdhub.cardinal.components.ComponentsEntityNetworking::initClient"
         ]
     },
     "custom": {

--- a/cardinal-components-level/src/main/resources/fabric.mod.json
+++ b/cardinal-components-level/src/main/resources/fabric.mod.json
@@ -9,6 +9,9 @@
     "entrypoints": {
         "main": [
             "nerdhub.cardinal.components.internal.ComponentsLevelNetworking::init"
+        ],
+        "client": [
+            "nerdhub.cardinal.components.internal.ComponentsLevelNetworking::initClient"
         ]
     },
     "custom": {

--- a/cardinal-components-world/src/main/resources/fabric.mod.json
+++ b/cardinal-components-world/src/main/resources/fabric.mod.json
@@ -9,6 +9,9 @@
     "entrypoints": {
         "main": [
             "nerdhub.cardinal.components.ComponentsWorldNetworking::init"
+        ],
+        "client": [
+            "nerdhub.cardinal.components.ComponentsWorldNetworking::initClient"
         ]
     },
     "custom": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ fabric_mining_levels_version=0.1.0+bdffbb2c
 fabric_tag_extensions_version=0.1.1+c189dc5c
 
 #Publishing
-mod_version = 2.0.0-SNAPSHOT
+mod_version = 2.0.1-SNAPSHOT
 curseforge_id = 318449
 curseforge_versions = 1.14; 1.14.1; 1.14.2; 1.14.3
 changelog_url = https://github.com/NerdHubMC/Cardinal-Components-API/changelog.md


### PR DESCRIPTION
This PR moves the `ClientSidePacketRegistry` calls to dedicated client initializers, fixing crashes on dedicated servers.