### PR TITLE
Add player respawning facilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,17 @@ Components can be added to entities of any type (modded or vanilla) by registeri
 Entity components are saved automatically with the entity. Synchronization must be done either manually or with
 help of the [`SyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/component/extension/SyncedComponent.java) 
 and [`EntitySyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/sync/EntitySyncedComponent.java) interfaces.
-
-**Notes:**
-- Player copies: When a player respawns after either dying or conquering the End, their data has to be copied.
-Components attached to players should use the [`PlayerCopyCallback`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java)
-to copy all or part of their component data.
+Cardinal Components also provides mechanisms for handling player respawns. By default, components get copied when
+players return from the End, but mods can customize that behaviour through [`RespawnCopyStrategy`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java)
+and [`PlayerCopyCallback`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java)
+to copy all or part of the component data.
 
 **Example:**
 ```java
 // Add the component to every instance of PlayerEntity
 EntityComponentCallback.event(PlayerEntity.class).register((player, components) -> components.put(MAGIK, new RandomIntComponent()));
+// Ensure the component's data is copied when keepInventory is enabled (Optional)
+EntityComponents.registerRespawnCopyStrat(MAGIK, RespawnCopyStrategy.INVENTORY);
 ```
 
 *module: cardinal-components-entity*

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ Entity components are saved automatically with the entity. Synchronization must 
 help of the [`SyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-base/src/main/java/nerdhub/cardinal/components/api/component/extension/SyncedComponent.java) 
 and [`EntitySyncedComponent`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/sync/EntitySyncedComponent.java) interfaces.
 
+**Notes:**
+- Player copies: When a player respawns after either dying or conquering the End, their data has to be copied.
+Components attached to players should use the [`PlayerCopyCallback`](https://github.com/NerdHubMC/Cardinal-Components-API/blob/master/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java)
+to copy all or part of their component data.
+
 **Example:**
 ```java
 // Add the component to every instance of PlayerEntity

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/CardinalComponentsEntity.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/CardinalComponentsEntity.java
@@ -56,7 +56,7 @@ public final class CardinalComponentsEntity {
         boolean keepInventory = original.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY) || clone.isSpectator();
         Components.forEach(ComponentProvider.fromEntity(original),
                 (type, from) -> type.maybeGet(clone).ifPresent(
-                        to -> EntityComponents.getRespawnCopyStrat((ComponentType) type).copyForRespawn(from, to, lossless, keepInventory)
+                        to -> EntityComponents.getRespawnCopyStrategy((ComponentType) type).copyForRespawn(from, to, lossless, keepInventory)
                 )
         );
     }

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
@@ -1,19 +1,25 @@
 /*
- * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ * Cardinal-Components-API
+ * Copyright (C) 2019 GlassPane
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 package nerdhub.cardinal.components.api.event;
 
 import nerdhub.cardinal.components.api.component.extension.CloneableComponent;

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
@@ -16,6 +16,7 @@
 
 package nerdhub.cardinal.components.api.event;
 
+import nerdhub.cardinal.components.api.component.extension.CloneableComponent;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -23,6 +24,8 @@ import net.minecraft.server.network.ServerPlayerEntity;
 /**
  * The callback interface for receiving player data copy events during
  * {@link ServerPlayerEntity#copyFrom(ServerPlayerEntity, boolean) player cloning}.
+ *
+ * @see CloneableComponent
  */
 @FunctionalInterface
 public interface PlayerCopyCallback {

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/event/PlayerCopyCallback.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nerdhub.cardinal.components.api.event;
+
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+/**
+ * The callback interface for receiving player data copy events during
+ * {@link ServerPlayerEntity#copyFrom(ServerPlayerEntity, boolean) player cloning}.
+ */
+@FunctionalInterface
+public interface PlayerCopyCallback {
+    Event<PlayerCopyCallback> EVENT = EventFactory.createArrayBacked(PlayerCopyCallback.class, (listeners) ->
+            (original, clone, lossless) -> {
+                for (PlayerCopyCallback callback : listeners) {
+                    callback.copyData(original, clone, lossless);
+                }
+            }
+    );
+
+    /**
+     * Copy mod data from a player to its clone.
+     *
+     * <p> When using an end portal from the End to the Overworld, a lossless copy will be made.
+     * In such cases, all data should be copied exactly between the original and the clone.
+     * Some data may also need exact copying when the {@link net.minecraft.world.GameRules#KEEP_INVENTORY keepInventory gamerule}
+     * is enabled, which needs to be checked independently using {@code clone.world.getGameRules()}.
+     * Otherwise, it is safe to simply ignore any data that should be reset with each death.
+     *
+     * <p> The {@code clone} is usually repositioned after this method has been called,
+     * invalidating position and dimension changes. The dimension of the {@code original}
+     * player itself has also been invalidated before this method is called, but is accessible
+     * through {@code original.world.dimension}.
+     *
+     * @param original the player that is being cloned
+     * @param clone    the clone of the {@code original} player
+     * @param lossless {@code true} if all the data should be copied exactly, {@code false} otherwise.
+     */
+    void copyData(ServerPlayerEntity original, ServerPlayerEntity clone, boolean lossless);
+
+}

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
@@ -1,0 +1,30 @@
+package nerdhub.cardinal.components.api.util;
+
+import nerdhub.cardinal.components.api.ComponentType;
+import nerdhub.cardinal.components.api.component.Component;
+import nerdhub.cardinal.components.internal.CardinalEntityInternals;
+
+public final class EntityComponents {
+
+    /**
+     * Register a respawn copy strategy for components of a given type.
+     *
+     * <p> When a player is cloned as part of the respawn process, its components are copied using
+     * a {@link RespawnCopyStrategy}. By default, the strategy used is {@link RespawnCopyStrategy#LOSSLESS_ONLY}.
+     * Calling this method allows one to customize the copy process.
+     *
+     * @param type     the representation of the registered type
+     * @param strategy a copy strategy to use when copying components between player instances
+     * @param <C>      the type of components affected
+     *
+     * @see nerdhub.cardinal.components.api.event.PlayerCopyCallback
+     * @see #getRespawnCopyStrat(ComponentType)
+     */
+    public static <C extends Component> void registerRespawnCopyStrat(ComponentType<C> type, RespawnCopyStrategy<C> strategy) {
+        CardinalEntityInternals.registerRespawnCopyStrat(type, strategy);
+    }
+
+    public static <C extends Component> RespawnCopyStrategy<C> getRespawnCopyStrat(ComponentType<C> type) {
+        return CardinalEntityInternals.getRespawnCopyStrat(type);
+    }
+}

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
@@ -29,7 +29,7 @@ import nerdhub.cardinal.components.internal.CardinalEntityInternals;
 public final class EntityComponents {
 
     /**
-     * Register a respawn copy strategy for components of a given type.
+     * Set the respawn copy strategy used for components of a given type.
      *
      * <p> When a player is cloned as part of the respawn process, its components are copied using
      * a {@link RespawnCopyStrategy}. By default, the strategy used is {@link RespawnCopyStrategy#LOSSLESS_ONLY}.
@@ -40,13 +40,13 @@ public final class EntityComponents {
      * @param <C>      the type of components affected
      *
      * @see nerdhub.cardinal.components.api.event.PlayerCopyCallback
-     * @see #getRespawnCopyStrat(ComponentType)
+     * @see #getRespawnCopyStrategy(ComponentType)
      */
-    public static <C extends Component> void registerRespawnCopyStrat(ComponentType<C> type, RespawnCopyStrategy<C> strategy) {
+    public static <C extends Component> void setRespawnCopyStrategy(ComponentType<C> type, RespawnCopyStrategy<C> strategy) {
         CardinalEntityInternals.registerRespawnCopyStrat(type, strategy);
     }
 
-    public static <C extends Component> RespawnCopyStrategy<C> getRespawnCopyStrat(ComponentType<C> type) {
+    public static <C extends Component> RespawnCopyStrategy<C> getRespawnCopyStrategy(ComponentType<C> type) {
         return CardinalEntityInternals.getRespawnCopyStrat(type);
     }
 }

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/EntityComponents.java
@@ -1,3 +1,25 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019 GlassPane
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package nerdhub.cardinal.components.api.util;
 
 import nerdhub.cardinal.components.api.ComponentType;

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
@@ -1,0 +1,39 @@
+package nerdhub.cardinal.components.api.util;
+
+import nerdhub.cardinal.components.api.component.Component;
+import net.minecraft.nbt.CompoundTag;
+
+@FunctionalInterface
+public interface RespawnCopyStrategy<C extends Component> {
+    void copyForRespawn(C from, C to, boolean lossless, boolean keepInventory);
+
+    /**
+     * Always copy a component no matter the cause of respawn.
+     * This strategy is relevant for persistent metadata such as stats.
+     */
+    RespawnCopyStrategy<?> ALWAYS_COPY = (from, to, lossless, keepInventory) -> copy(from, to);
+
+    /**
+     * Copy a component whenever the player's inventory would be copied.
+     * This strategy is relevant for any data storage tied to items or experience.
+     */
+    RespawnCopyStrategy<?> INVENTORY = (from, to, lossless, keepInventory) -> {
+        if (lossless || keepInventory) {
+            copy(from, to);
+        }
+    };
+
+    /**
+     * Copy a component only when the entire data is transferred from a player to the other.
+     * This strategy is the default.
+     */
+    RespawnCopyStrategy<?> LOSSLESS_ONLY = (from, to, lossless, keepInventory) -> {
+        if (lossless) {
+            copy(from, to);
+        }
+    };
+
+    static <C extends Component> void copy(C from, C to) {
+        to.fromTag(from.toTag(new CompoundTag()));
+    }
+}

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
@@ -1,3 +1,25 @@
+/*
+ * Cardinal-Components-API
+ * Copyright (C) 2019 GlassPane
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package nerdhub.cardinal.components.api.util;
 
 import nerdhub.cardinal.components.api.ComponentType;

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
@@ -26,11 +26,12 @@ import nerdhub.cardinal.components.api.ComponentType;
 import nerdhub.cardinal.components.api.component.Component;
 import nerdhub.cardinal.components.api.event.PlayerCopyCallback;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.GameRules;
 
 /**
  * Represents a strategy to copy a component from a player to another.
  *
- * <p> Copy strategies can be registered using {@link EntityComponents#registerRespawnCopyStrat(ComponentType, RespawnCopyStrategy)}.
+ * <p> Copy strategies can be registered using {@link EntityComponents#setRespawnCopyStrategy(ComponentType, RespawnCopyStrategy)}.
  *
  * @param <C> the type of components handled by this strategy
  * @see PlayerCopyCallback
@@ -38,6 +39,15 @@ import net.minecraft.nbt.CompoundTag;
  */
 @FunctionalInterface
 public interface RespawnCopyStrategy<C extends Component> {
+    /**
+     * Copy data from a component to another as part of a player respawn.
+     *
+     * @param from          the component to copy data from
+     * @param to            the component to copy data to
+     * @param lossless      {@code true} if the player is copied exactly, such as when coming back from the End
+     * @param keepInventory {@code true} if the player's inventory and XP are kept, such as when
+     *                      {@link GameRules#KEEP_INVENTORY} is enabled or the player is in spectator mode
+     */
     void copyForRespawn(C from, C to, boolean lossless, boolean keepInventory);
 
     /**

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/api/util/RespawnCopyStrategy.java
@@ -1,8 +1,19 @@
 package nerdhub.cardinal.components.api.util;
 
+import nerdhub.cardinal.components.api.ComponentType;
 import nerdhub.cardinal.components.api.component.Component;
+import nerdhub.cardinal.components.api.event.PlayerCopyCallback;
 import net.minecraft.nbt.CompoundTag;
 
+/**
+ * Represents a strategy to copy a component from a player to another.
+ *
+ * <p> Copy strategies can be registered using {@link EntityComponents#registerRespawnCopyStrat(ComponentType, RespawnCopyStrategy)}.
+ *
+ * @param <C> the type of components handled by this strategy
+ * @see PlayerCopyCallback
+ * @see EntityComponents
+ */
 @FunctionalInterface
 public interface RespawnCopyStrategy<C extends Component> {
     void copyForRespawn(C from, C to, boolean lossless, boolean keepInventory);
@@ -32,6 +43,13 @@ public interface RespawnCopyStrategy<C extends Component> {
             copy(from, to);
         }
     };
+
+    /**
+     * Never copy a component no matter the cause of respawn.
+     * This strategy can be used when {@code RespawnCopyStrategy} does not offer enough context,
+     * in which case {@link PlayerCopyCallback} may be used directly.
+     */
+    RespawnCopyStrategy<?> NEVER_COPY = (from, to, lossless, keepInventory) -> {};
 
     static <C extends Component> void copy(C from, C to) {
         to.fromTag(from.toTag(new CompoundTag()));

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/internal/CardinalEntityInternals.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/internal/CardinalEntityInternals.java
@@ -24,8 +24,10 @@ package nerdhub.cardinal.components.internal;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import nerdhub.cardinal.components.api.ComponentType;
 import nerdhub.cardinal.components.api.component.Component;
 import nerdhub.cardinal.components.api.event.EntityComponentCallback;
+import nerdhub.cardinal.components.api.util.RespawnCopyStrategy;
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 import net.minecraft.entity.Entity;
@@ -40,6 +42,7 @@ public final class CardinalEntityInternals {
 
     private static final Map<Class<? extends Entity>, Event> ENTITY_EVENTS = new HashMap<>();
     private static final Map<Class<? extends Entity>, FeedbackContainerFactory<Entity, Component>> ENTITY_CONTAINER_FACTORIES = new HashMap<>();
+    private static final Map<ComponentType<?>, RespawnCopyStrategy<?>> RESPAWN_COPY_STRATEGIES = new HashMap<>();
 
     @SuppressWarnings("unchecked")
     public static <T extends Entity> Event<EntityComponentCallback<T>> event(Class<T> clazz) {
@@ -76,4 +79,12 @@ public final class CardinalEntityInternals {
         });
     }
 
+    public static <C extends Component> void registerRespawnCopyStrat(ComponentType<C> type, RespawnCopyStrategy<C> strategy) {
+        RESPAWN_COPY_STRATEGIES.put(type, strategy);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <C extends Component> RespawnCopyStrategy<C> getRespawnCopyStrat(ComponentType<C> type) {
+        return (RespawnCopyStrategy<C>) RESPAWN_COPY_STRATEGIES.getOrDefault(type, RespawnCopyStrategy.LOSSLESS_ONLY);
+    }
 }

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/mixins/common/MixinPlayerManager.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/mixins/common/MixinPlayerManager.java
@@ -26,10 +26,12 @@ import nerdhub.cardinal.components.api.event.PlayerSyncCallback;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.world.dimension.DimensionType;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PlayerManager.class)
 public abstract class MixinPlayerManager {
@@ -42,5 +44,13 @@ public abstract class MixinPlayerManager {
     )
     private void onPlayerLogIn(ClientConnection connection, ServerPlayerEntity player, CallbackInfo ci) {
         PlayerSyncCallback.EVENT.invoker().onPlayerSync(player);
+    }
+
+    @Inject(
+            method = "respawnPlayer",
+            at = @At("RETURN")
+    )
+    private void respawnPlayer(ServerPlayerEntity player, DimensionType dimension, boolean end, CallbackInfoReturnable<ServerPlayerEntity> cir) {
+        PlayerSyncCallback.EVENT.invoker().onPlayerSync(cir.getReturnValue());
     }
 }

--- a/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/mixins/common/MixinServerPlayerEntity.java
+++ b/cardinal-components-entity/src/main/java/nerdhub/cardinal/components/mixins/common/MixinServerPlayerEntity.java
@@ -22,6 +22,7 @@
  */
 package nerdhub.cardinal.components.mixins.common;
 
+import nerdhub.cardinal.components.api.event.PlayerCopyCallback;
 import nerdhub.cardinal.components.api.event.PlayerSyncCallback;
 import nerdhub.cardinal.components.api.event.TrackingStartCallback;
 import net.minecraft.entity.Entity;
@@ -43,5 +44,10 @@ public abstract class MixinServerPlayerEntity {
     @Inject(method = "changeDimension", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayerEntity;getStatusEffects()Ljava/util/Collection;"))
     private void onDimensionChange(DimensionType dimension, CallbackInfoReturnable<Entity> cir) {
         PlayerSyncCallback.EVENT.invoker().onPlayerSync((ServerPlayerEntity)(Object) this);
+    }
+
+    @Inject(method = "copyFrom", at = @At("RETURN"))
+    private void copyDataFrom(ServerPlayerEntity original, boolean lossless, CallbackInfo ci) {
+        PlayerCopyCallback.EVENT.invoker().copyData(original, (ServerPlayerEntity) (Object) this, lossless);
     }
 }

--- a/cardinal-components-entity/src/main/resources/fabric.mod.json
+++ b/cardinal-components-entity/src/main/resources/fabric.mod.json
@@ -8,10 +8,10 @@
     "side": "universal",
     "entrypoints": {
         "main": [
-          "nerdhub.cardinal.components.ComponentsEntityNetworking::init"
+          "nerdhub.cardinal.components.CardinalComponentsEntity::init"
         ],
         "client": [
-            "nerdhub.cardinal.components.ComponentsEntityNetworking::initClient"
+            "nerdhub.cardinal.components.CardinalComponentsEntity::initClient"
         ]
     },
     "custom": {


### PR DESCRIPTION
Currently, mods have to rely on a third-party player respawn event to copy their component data as part of the respawning process. Moreover, even with such an event, it is easy to overlook the special case of respawning from the End, making proper respawn handling somewhat tricky.
This PR aims at alleviating both those issues, by introducing a `PlayerCopyCallback`, as well as a component-specific API using `RespawnCopyStrategy`. It also includes a fix to `PlayerSyncCallback` not getting called when players respawn.